### PR TITLE
Fix json request builder

### DIFF
--- a/lib/senders/http/request/base_request_builder.dart
+++ b/lib/senders/http/request/base_request_builder.dart
@@ -12,9 +12,7 @@ class BaseRequestBuilder {
       pendingRequest.uri,
     );
 
-    pendingRequest.headers.forEach((key, value) {
-      request.headers[key] = value;
-    });
+    request.headers.addAll(pendingRequest.headers);
 
     return request;
   }

--- a/lib/senders/http/request/form_body_request_builder.dart
+++ b/lib/senders/http/request/form_body_request_builder.dart
@@ -14,9 +14,15 @@ class FormBodyRequestBuilder {
       throw 'PendingRequest must have a body of type FormBody';
     }
 
-    return http.Request(
+    final request = http.Request(
       pendingRequest.method.name,
       pendingRequest.uri,
-    )..bodyFields = body.fields;
+    );
+
+    request.bodyFields = body.fields;
+
+    request.headers.addAll(pendingRequest.headers);
+
+    return request;
   }
 }

--- a/lib/senders/http/request/json_request_builder.dart
+++ b/lib/senders/http/request/json_request_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:http/http.dart' as http;
 import 'package:saloon/contracts/request_body.dart';
 import 'package:saloon/pending_request.dart';
@@ -14,9 +16,17 @@ class JsonBodyRequestBuilder {
       throw 'PendingRequest must have a body of type JsonBody';
     }
 
-    return http.Request(
+    final request = http.Request(
       pendingRequest.method.name,
       pendingRequest.uri,
-    )..body = body.json.toString();
+    );
+
+    request.headers.addAll(pendingRequest.headers);
+
+    request.body = jsonEncode(body.json);
+
+    request.headers['Content-Type'] = 'application/json';
+
+    return request;
   }
 }

--- a/lib/senders/http/request/request_builder.dart
+++ b/lib/senders/http/request/request_builder.dart
@@ -3,7 +3,7 @@ import 'package:saloon/contracts/request_body.dart';
 import 'package:saloon/pending_request.dart';
 import 'package:saloon/senders/http/request/base_request_builder.dart';
 import 'package:saloon/senders/http/request/form_body_request_builder.dart';
-import 'package:saloon/senders/http/request/json_request_request_builder.dart';
+import 'package:saloon/senders/http/request/json_request_builder.dart';
 import 'package:saloon/senders/http/request/multipart_body_request_builder.dart';
 
 class RequestBuilder {


### PR DESCRIPTION
This PR fix json request builder and apply missing headers:

- When using `.toString`, the JSON is not serialized in the format expected by the API, causing the error: "JSON parse error." Therefore, I replaced it with `jsonEncode`, which correctly transforms the data.
- I manually added the Content-Type: application/json header because the HTTP library does not set it automatically, instead generating the following header: `Content-Type: text/plain; charset=utf-8`. To address this, we now explicitly apply the correct header.
- The part of merging headers where it was missing has been added in file: `form_body_request_builder.dart`