### PR TITLE
Allow absolute URLs for requests classes

### DIFF
--- a/lib/pending_request.dart
+++ b/lib/pending_request.dart
@@ -42,6 +42,10 @@ class PendingRequest {
     final requestEndpoint = await request.resolveEndpoint();
     final connectorBaseuUrl = await connector.resolveBaseUrl();
 
+    if (Uri.tryParse(requestEndpoint)?.hasScheme ?? false) {
+      return requestEndpoint;
+    }
+
     return urlJoin(connectorBaseuUrl, requestEndpoint);
   }
 

--- a/test/unit/http/pending_request_test.dart
+++ b/test/unit/http/pending_request_test.dart
@@ -34,6 +34,14 @@ class CustomRequest extends Request implements HasBody<JsonBody> {
   }
 }
 
+class AbsoluteUrlOverrideRequest extends Request {
+  @override
+  Future<String> resolveEndpoint() async => "https://custom.api.url";
+
+  @override
+  Future<Method> resolveMethod() async => Method.get;
+}
+
 void main() {
   test('can build', () async {
     final subject = await PendingRequest(
@@ -54,5 +62,14 @@ void main() {
       'custom': 'headers',
       'Authorization': 'Bearer token',
     });
+  });
+
+  test('should override base URL with absolute URL', () async {
+    final subject = await PendingRequest(
+      connector: CustomConnector(),
+      request: AbsoluteUrlOverrideRequest(),
+    ).build();
+
+    expect(subject.url, 'https://custom.api.url');
   });
 }


### PR DESCRIPTION
# Changes

- Now, in the `_getEndpoint()` method, when requestEndpoint has a scheme (e.g., https:// or http://), we return it as is, without merging it with the base URL of the connector.

Reason: Previously, every dispatched request would merge the endpoint with the connector's base URL. However, this prevented us from using a completely new URL when needed. For example, when making a `POST` or `PUT` request to a file storage bucket for direct uploads, the forced merging made it impossible. This change allows such requests to function correctly.

