### PR TITLE
Adds binary body and fix uri method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ build/
 
 # Mockito
 *.mocks.dart
+
+test_temp_file.bin

--- a/lib/contracts/request_body.dart
+++ b/lib/contracts/request_body.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 sealed class RequestBody {}
 
@@ -22,4 +23,10 @@ final class MultipartBody implements RequestBody {
     this.fields = const {},
     this.files = const {},
   });
+}
+
+final class BinaryBody implements RequestBody {
+  final Uint8List bytes;
+
+  BinaryBody(this.bytes);
 }

--- a/lib/pending_request.dart
+++ b/lib/pending_request.dart
@@ -35,7 +35,14 @@ class PendingRequest {
   }
 
   Uri get uri {
-    return Uri.parse(url).replace(queryParameters: params);
+    final originalUri = Uri.parse(url);
+
+    final combinedQueryParams = {
+      ...originalUri.queryParameters,
+      ...?params,
+    };
+
+    return originalUri.replace(queryParameters: combinedQueryParams);
   }
 
   Future<String> _getEndpoint() async {

--- a/lib/senders/http/request/binary_body_request_builder.dart
+++ b/lib/senders/http/request/binary_body_request_builder.dart
@@ -1,0 +1,29 @@
+import 'package:http/http.dart' as http;
+import 'package:saloon/saloon.dart';
+
+class BinaryBodyRequestBuilder {
+  final PendingRequest pendingRequest;
+
+  BinaryBodyRequestBuilder(this.pendingRequest);
+
+  Future<http.BaseRequest> build() async {
+    final body = pendingRequest.body;
+
+    if (body is! BinaryBody) {
+      throw 'PendingRequest must have a body of type BinaryBody';
+    }
+
+    final request = http.Request(
+      pendingRequest.method.name,
+      pendingRequest.uri,
+    );
+
+    request.headers['Content-Type'] = 'application/octet-stream';
+
+    request.headers.addAll(pendingRequest.headers);
+
+    request.bodyBytes = body.bytes;
+
+    return request;
+  }
+}

--- a/lib/senders/http/request/request_builder.dart
+++ b/lib/senders/http/request/request_builder.dart
@@ -2,6 +2,7 @@ import 'package:http/http.dart' as http;
 import 'package:saloon/contracts/request_body.dart';
 import 'package:saloon/pending_request.dart';
 import 'package:saloon/senders/http/request/base_request_builder.dart';
+import 'package:saloon/senders/http/request/binary_body_request_builder.dart';
 import 'package:saloon/senders/http/request/form_body_request_builder.dart';
 import 'package:saloon/senders/http/request/json_request_builder.dart';
 import 'package:saloon/senders/http/request/multipart_body_request_builder.dart';
@@ -19,6 +20,8 @@ class RequestBuilder {
         return FormBodyRequestBuilder(pendingRequest).build();
       case MultipartBody _:
         return MultipartBodyRequestBuilder(pendingRequest).build();
+      case BinaryBody _:
+        return BinaryBodyRequestBuilder(pendingRequest).build();
       default:
         return BaseRequestBuilder(pendingRequest).build();
     }

--- a/test/unit/http/pending_request_test.dart
+++ b/test/unit/http/pending_request_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:saloon/saloon.dart';
 
@@ -42,6 +44,17 @@ class AbsoluteUrlOverrideRequest extends Request {
   Future<Method> resolveMethod() async => Method.get;
 }
 
+class CustomQueryRequest extends Request {
+  @override
+  Future<String> resolveEndpoint() async => "/users?id=4";
+
+  @override
+  Future<Method> resolveMethod() async => Method.get;
+
+  @override
+  FutureOr<QueryParams> resolveQueryParams() => {"name": "John"};
+}
+
 void main() {
   test('can build', () async {
     final subject = await PendingRequest(
@@ -71,5 +84,14 @@ void main() {
     ).build();
 
     expect(subject.url, 'https://custom.api.url');
+  });
+
+  test('should correctly concatenate query parameters in the URL', () async {
+    final subject = await PendingRequest(
+      connector: CustomConnector(),
+      request: CustomQueryRequest(),
+    ).build();
+
+    expect(subject.uri.toString(), 'https://example.api/users?id=4&name=John');
   });
 }

--- a/test/unit/http/request/binary_body_request_builder_test.dart
+++ b/test/unit/http/request/binary_body_request_builder_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saloon/saloon.dart';
+import 'package:saloon/senders/http/request/binary_body_request_builder.dart';
+import 'package:http/http.dart' as http;
+
+Future<File> _createTempBinaryFile() async {
+  final tempDir = Directory.systemTemp;
+  final tempFile = File('${tempDir.path}/test-binary-file.bin');
+
+  await tempFile.writeAsBytes([0, 1, 2, 3, 4]);
+  return tempFile;
+}
+
+Future<File> _createTempTextFile() async {
+  final tempDir = Directory.systemTemp;
+  final tempFile = File('${tempDir.path}/test-text-file.txt');
+
+  await tempFile.writeAsString('File test.');
+  return tempFile;
+}
+
+class CustomBinaryRequest extends Request implements HasBody<BinaryBody> {
+  @override
+  Future<Method> resolveMethod() async => Method.post;
+
+  @override
+  Future<String> resolveEndpoint() async => "/upload";
+
+  @override
+  Future<BinaryBody> resolveBody() async {
+    final file = await _createTempBinaryFile();
+    return BinaryBody(await file.readAsBytes());
+  }
+}
+
+class OverridesContentTypeRequest extends Request
+    implements HasBody<BinaryBody> {
+  @override
+  Future<Method> resolveMethod() async => Method.post;
+
+  @override
+  Future<String> resolveEndpoint() async => "/upload";
+
+  @override
+  Future<BinaryBody> resolveBody() async {
+    final file = await _createTempTextFile();
+    return BinaryBody(await file.readAsBytes());
+  }
+
+  @override
+  FutureOr<Headers> resolveHeaders() {
+    return {'Content-Type': 'text/plain'};
+  }
+}
+
+class CustomConnector extends Connector {
+  @override
+  Future<String> resolveBaseUrl() async => 'https://example.api';
+}
+
+void main() {
+  test('should build request with binary body', () async {
+    final pendingRequest = await PendingRequest(
+      connector: CustomConnector(),
+      request: CustomBinaryRequest(),
+    ).build();
+
+    final binaryBuilder = BinaryBodyRequestBuilder(pendingRequest);
+    final request = await binaryBuilder.build();
+
+    expect(request, isA<http.Request>());
+    expect((request as http.Request).bodyBytes, [0, 1, 2, 3, 4]);
+    expect(request.headers['Content-Type'], 'application/octet-stream');
+  });
+
+  test('should overrides the content-type', () async {
+    final pendingRequest = await PendingRequest(
+      connector: CustomConnector(),
+      request: OverridesContentTypeRequest(),
+    ).build();
+
+    final binaryBuilder = BinaryBodyRequestBuilder(pendingRequest);
+    final request = await binaryBuilder.build();
+
+    expect(request.headers['Content-Type'], 'text/plain');
+  });
+}


### PR DESCRIPTION
# Changes

- Adds binary body in request body. This addition provides an easier way to send binary body, as all you need to do is add the bytes (`Uint8List`).
- Fixes URI method, which was incorrectly deleting existing queries, performing a full replace instead of an append. All related tests have been updated.