### PR TITLE
Adds fixture source in fromFixture method

### DIFF
--- a/lib/faking/response/fixture_type.dart
+++ b/lib/faking/response/fixture_type.dart
@@ -1,0 +1,4 @@
+enum FixtureSource {
+  asset,
+  file,
+}

--- a/lib/faking/response/mock_response.dart
+++ b/lib/faking/response/mock_response.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
-
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:saloon/faking/response/fixture_type.dart';
 import 'package:saloon/saloon.dart';
 
 typedef MockResponseWhen = bool Function(PendingRequest pending);
@@ -19,9 +20,14 @@ class MockResponse {
   static Future<MockResponse> fromFixture(
     String path, {
     required Type request,
+    FixtureSource source = FixtureSource.file,
     MockResponseWhen? when,
   }) async {
-    final fixture = await File(path).readAsString();
+    final fixture = switch (source) {
+      FixtureSource.asset => await rootBundle.loadString(path),
+      FixtureSource.file => await File(path).readAsString(),
+    };
+
     final json = jsonDecode(fixture);
 
     final response = json['body'] is Map


### PR DESCRIPTION
This PR adds fixture source in fromFixture method:

- This addition is necessary because, when running tests with Patrol and using fixture mocks, the fixture files need to be placed in the assets and accessed via rootBundle. This is because using File.readAsString() results in a "file not found" error. @hjJunior suggested placing this addition in lib as well, since it might be useful in other scenarios as a utility.

- I didn't add a test because we would need to convert this project into a Flutter project to be able to use assets.